### PR TITLE
added zsh file to work with oh-my-zsh

### DIFF
--- a/zsh-autosuggestions.plugin.zsh
+++ b/zsh-autosuggestions.plugin.zsh
@@ -1,0 +1,1 @@
+autosuggestions.plugin.zsh


### PR DESCRIPTION
oh-my-zsh needs the plugin folder name to be the same as the .plugin.zsh filename

This can be checked in oh-my-zsh.sh file in the is_plugin() function.