### PR TITLE
Fix highlight cache invalidation

### DIFF
--- a/autosuggestions.zsh
+++ b/autosuggestions.zsh
@@ -250,7 +250,7 @@ autosuggest-accept-suggestion() {
 
 autosuggest-invalidate-highlight-cache() {
 	# invalidate the buffer for zsh-syntax-highlighting
-	_ZSH_HIGHLIGHT_PRIOR_BUFFER=''
+	_zsh_highlight_autosuggest_highlighter_cache=()
 }
 
 zle -N autosuggest-toggle


### PR DESCRIPTION
This (at least partially) fixes #6 and https://github.com/zsh-users/zsh-syntax-highlighting/issues/164. Highlighting now works correctly when completion is accepted using Ctrl+e (end-of-line), but doesn’t work well when I paste some command to terminal from the clipboard.