### PR TITLE
Add alternative install/uninstall script.

### DIFF
--- a/.zsh-autosuggestionsrc
+++ b/.zsh-autosuggestionsrc
@@ -1,5 +1,5 @@
 # Setup zsh-autosuggestions
-source $DIR/autosuggestions.zsh
+source $HOME/.zsh-autosuggestions/autosuggestions.zsh
 
 # Enable autosuggestions automatically
 zle-line-init() {

--- a/.zsh-autosuggestionsrc
+++ b/.zsh-autosuggestionsrc
@@ -1,0 +1,13 @@
+# Setup zsh-autosuggestions
+source $DIR/autosuggestions.zsh
+
+# Enable autosuggestions automatically
+zle-line-init() {
+    zle autosuggest-start
+}
+
+zle -N zle-line-init
+
+# use ctrl+t to toggle autosuggestions(hopefully this wont be needed as
+# zsh-autosuggestions is designed to be unobtrusive)
+bindkey '^T' autosuggest-toggle

--- a/alt-install
+++ b/alt-install
@@ -1,0 +1,73 @@
+#!/bin/bash
+# An alternative install script for zsh-autocomplete.
+#
+DESCRIPTION="this script adds/removes a   
+.zsh-autosuggestionsrc reference to your .zshrc file."
+ZSHRC=""
+
+function usage()
+{
+        echo $0 : $DESCRIPTION
+        echo "Usage"
+        echo -e "\t" $0 " install   : attempts to install"
+        echo -e "\t" $0 " uninstall : attempts to uninstall"
+        exit 1
+}
+
+function install()
+{
+	PATH_TO_RC="source "$(pwd)"/.zsh-autosuggestionsrc"
+	# check if line exists in zshrc, add it if missing
+	if grep -Fxq "$PATH_TO_RC" "$ZSHRC"
+	then
+		echo "currently installed, see $ZSHRC" 
+	else
+		echo "Backing up $ZSHRC to $ZSHRC.bak"
+		cp "$ZSHRC" "$ZSHRC.bak"
+		echo "Adding $PATH_TO_RC to $ZSHRC"
+		echo "$PATH_TO_RC" >> "$ZSHRC"
+	fi
+}
+
+function uninstall()
+{
+	PATH_TO_RC="source "$(pwd)"/.zsh-autosuggestionsrc"
+	# check if line exists in zshrc, remove if preset
+	if grep -Fxq "$PATH_TO_RC" "$ZSHRC"
+	then
+		echo "Removing $PATH_TO_RC from $ZSHRC"
+		grep -v "$PATH_TO_RC" "$ZSHRC" > "tmp-zsh-autosuggestion"
+		cat "tmp-zsh-autosuggestion" > "$ZSHRC"
+		rm "tmp-zsh-autosuggestion"
+	else
+		echo "not currently installed, see $ZSHRC"
+	fi
+}
+
+function get_zhsrc()
+{
+	# attempt to find a .zshrc
+	# check if it exists and writeable
+	if [ -w "$HOME/.zshrc" ] ; then
+		ZSHRC="$HOME/.zshrc"
+	elif [ -w "$ZDOTDIR/.zshrc" ] ; then
+		ZSHRC="$ZDOTDIR/.zshrc"
+	else
+		echo "Cannot find .zshrc "
+		exit -1
+	fi
+}
+
+function main()
+{
+	if [ "$1" == "install" ] ; then
+		get_zhsrc
+		install "$@"
+	elif [ "$1" == "uninstall" ] ; then
+		get_zhsrc
+		uninstall "$@"
+	else
+		usage
+	fi
+}
+main "$@" # $@ passes args to main.

--- a/alt-install
+++ b/alt-install
@@ -4,6 +4,7 @@
 DESCRIPTION="this script adds/removes a   
 .zsh-autosuggestionsrc reference to your .zshrc file."
 ZSHRC=""
+PATH_TO_RC="source $HOME/.zsh-autosuggestions/.zsh-autosuggestionsrc"
 
 function usage()
 {
@@ -16,7 +17,7 @@ function usage()
 
 function install()
 {
-	PATH_TO_RC="source "$(pwd)"/.zsh-autosuggestionsrc"
+
 	# check if line exists in zshrc, add it if missing
 	if grep -Fxq "$PATH_TO_RC" "$ZSHRC"
 	then
@@ -31,7 +32,6 @@ function install()
 
 function uninstall()
 {
-	PATH_TO_RC="source "$(pwd)"/.zsh-autosuggestionsrc"
 	# check if line exists in zshrc, remove if preset
 	if grep -Fxq "$PATH_TO_RC" "$ZSHRC"
 	then


### PR DESCRIPTION
Instead of adding multiple conf lines to .zshrc, provide them in .zsh-autosuggestionsrc and add/remove a one line reference to it in .zshrc using "source".

This also allows future configuration changes to be made to .zsh-autosugestionsrc under version control, requiring no updates/changes in user .zshrc.

Summary:
+ Adds alt-installation method.
+ Adds uninstall method ( #54 ).
+ Resolves ( #46 ).
+ Will not double install on multiple invocations like the existing install script.
+ Creates a backup of .zshrc to .zshrc.bak
+ Compatible but untested with $ZDOTDIR

Caveats
+ Requires repository be located in $HOME/.zsh-autosuggestions (as with existing install method)