### PR TITLE
Add widget autosuggest-execute-suggestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ bindkey '^T' autosuggest-toggle
 List of widgets:
 
  - `autosuggest-toggle` – disable/enable autosuggestions.
+ - `autosuggest-execute-suggestion` – accept the suggestion and execute it.
 
 
 ## Configuration

--- a/autosuggestions.zsh
+++ b/autosuggestions.zsh
@@ -250,6 +250,15 @@ autosuggest-accept-suggestion() {
 	fi
 }
 
+autosuggest-execute-suggestion() {
+	if [[ -n $ZLE_AUTOSUGGESTING ]]; then
+		zle autosuggest-end-of-line-orig
+		autosuggest-invalidate-highlight-cache
+		autosuggest-highlight-suggested-text
+	fi
+	zle .accept-line
+}
+
 autosuggest-invalidate-highlight-cache() {
 	# invalidate the buffer for zsh-syntax-highlighting
 	_zsh_highlight_autosuggest_highlighter_cache=()
@@ -259,6 +268,7 @@ zle -N autosuggest-toggle
 zle -N autosuggest-start
 zle -N autosuggest-accept-suggested-small-word
 zle -N autosuggest-accept-suggested-word
+zle -N autosuggest-execute-suggestion
 
 zle -N autosuggest-paused-self-insert
 zle -N autosuggest-insert-or-space


### PR DESCRIPTION
It basically means this: go to the end of line (i.e. accept the suggestion) and then hit enter.

I have binded this widget to Cmd + Enter in my terminal and it’s extremely convenient. :smile_cat:

/cc @faceleg